### PR TITLE
Add non HTTP 200 handling for all response processing in DespatchCloudHttpClient

### DIFF
--- a/src/DespatchCloudHttpClient.cs
+++ b/src/DespatchCloudHttpClient.cs
@@ -156,7 +156,7 @@ namespace GardeningExpress.DespatchCloudClient
         }
 
         public async Task<ApiResponse<Inventory>> GetInventoryBySKUAsync(string sku, CancellationToken cancellationToken = default)
-        {
+        {   
             var searchFilters = new InventorySearchFilters
             {
                 SKU = sku
@@ -213,24 +213,22 @@ namespace GardeningExpress.DespatchCloudClient
         private async Task<ListResponse<T>> CreateErrorListResponse<T>(HttpResponseMessage response)
         {
             var errorResponse = await DeserializeResponse<DespatchCloudErrorResponse>(response);
-
-            var errorMessage = errorResponse != null
-                ? errorResponse.Error
-                : $"Response from DespatchCloud: {response.StatusCode}";
-
+            var errorMessage = GetErrorMessageFromResponseMessage(errorResponse, response);
             return CreateErrorListResponse<T>(errorMessage);
         }
 
         private async Task<ApiResponse> CreateErrorApiResponse(HttpResponseMessage response)
         {
             var errorResponse = await DeserializeResponse<DespatchCloudErrorResponse>(response);
-            return CreateErrorApiResponse(errorResponse.Error);
+            var errorMessage = GetErrorMessageFromResponseMessage(errorResponse, response);
+            return CreateErrorApiResponse(errorMessage);
         }
 
         private async Task<ApiResponse<T>> CreateErrorApiResponse<T>(HttpResponseMessage response)
         {
             var errorResponse = await DeserializeResponse<DespatchCloudErrorResponse>(response);
-            return CreateErrorApiResponse<T>(errorResponse.Error);
+            var errorMessage = GetErrorMessageFromResponseMessage(errorResponse, response);
+            return CreateErrorApiResponse<T>(errorMessage);
         }
 
         private static ApiResponse CreateErrorApiResponse(string errorMessage)
@@ -249,6 +247,13 @@ namespace GardeningExpress.DespatchCloudClient
         {
             var json = JsonConvert.SerializeObject(obj, _jsonSerializerSettings);
             return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private string GetErrorMessageFromResponseMessage(DespatchCloudErrorResponse despatchCloudErrorResponse, HttpResponseMessage httpResponse)
+        {
+            return (despatchCloudErrorResponse == null || despatchCloudErrorResponse.Error == null)
+                ? $"Response from DespatchCloud: {(int)httpResponse.StatusCode} - {httpResponse.ReasonPhrase ?? ""}"
+                : despatchCloudErrorResponse.Error;
         }
     }
 }

--- a/src/DespatchCloudHttpClient.cs
+++ b/src/DespatchCloudHttpClient.cs
@@ -252,7 +252,7 @@ namespace GardeningExpress.DespatchCloudClient
         private string GetErrorMessageFromResponseMessage(DespatchCloudErrorResponse despatchCloudErrorResponse, HttpResponseMessage httpResponse)
         {
             return (despatchCloudErrorResponse == null || despatchCloudErrorResponse.Error == null)
-                ? $"Response from DespatchCloud: {(int)httpResponse.StatusCode} - {httpResponse.ReasonPhrase ?? ""}"
+                ? $"Response from DespatchCloud: {(int)httpResponse.StatusCode} - {httpResponse.ReasonPhrase ?? "<reasonphrase not defined>"}"
                 : despatchCloudErrorResponse.Error;
         }
     }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/CreateOrderAsyncTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/CreateOrderAsyncTests.cs
@@ -83,5 +83,24 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Integration
 
             result2.Error.ShouldBe($"The Channel Order ID ({channelOrderId}) is already in use.");
         }
+
+        
+        [Test]
+        public async Task CreateOrderAsync_WithInvalidManualChannelId_ShouldReturnAHttp422ErrorMessage()
+        {
+            // 422 response occurs when manualchannelid is wrong
+            // ARRANGE
+            var channelOrderId = $"Test-{DateTime.Now.Ticks}";
+            var order = _newOrder with { ChannelOrderId = channelOrderId };
+            order.ManualChannelId = 1234;
+
+            // ACT
+            var result1 = await DespatchCloudHttpClient.CreateOrderAsync(order);
+
+            // ASSERT
+            Assert.IsFalse(result1.IsSuccess);
+            Assert.IsNotNull(result1.Error);
+            Assert.AreEqual("Response from DespatchCloud: 422 - Unprocessable Entity", result1.Error);
+        }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Inventory/DespatchCloudSearchInventoryTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Inventory/DespatchCloudSearchInventoryTests.cs
@@ -62,7 +62,7 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Inventory
                     SKU = "test"
                 });
 
-            apiResponse.Error.ShouldBe("Response from DespatchCloud: 520 - ");
+            apiResponse.Error.ShouldBe("Response from DespatchCloud: 520 - <reasonphrase not defined>");
         }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Inventory/DespatchCloudSearchInventoryTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Inventory/DespatchCloudSearchInventoryTests.cs
@@ -62,7 +62,7 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Inventory
                     SKU = "test"
                 });
 
-            apiResponse.Error.ShouldBe("Response from DespatchCloud: 520");
+            apiResponse.Error.ShouldBe("Response from DespatchCloud: 520 - ");
         }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Orders/SetOrderStatusAsyncTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Orders/SetOrderStatusAsyncTests.cs
@@ -1,0 +1,60 @@
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Contrib.HttpClient;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Orders;
+
+[TestFixture]
+public class SetOrderStatusAsyncTests
+{
+
+    private readonly DespatchCloudConfig _despatchCloudConfig = new DespatchCloudConfig
+    {
+        ApiBaseUrl = "https://fake.api",
+        LoginPassword = "secret",
+        LoginEmailAddress = "test@test.com"
+    };
+
+    private Mock<HttpMessageHandler> _handler;
+    private DespatchCloudHttpClient _despatchCloudHttpClient;
+
+
+    [SetUp]
+    public void Setup()
+    {
+        _handler = new Mock<HttpMessageHandler>();
+        var httpClient = _handler.CreateClient();
+        httpClient.BaseAddress = new Uri(_despatchCloudConfig.ApiBaseUrl);
+
+        _despatchCloudHttpClient = new DespatchCloudHttpClient(httpClient);
+    }
+    
+    [Test]
+    public async Task SetOrderStatusAsync_ShouldReturnIsSuccessFalse_AndErrorMessage_WhenNon200ResponseOccurs()
+    {
+        // ARRANGE
+        var uriString = $"{_despatchCloudConfig.ApiBaseUrl}order/{12331444}/update";
+        var uri = new Uri(uriString);
+
+        _handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+            ItExpr.Is<HttpRequestMessage>(r => r.RequestUri == uri && r.Method == HttpMethod.Post),
+            ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = "Internal Server Error"
+            });
+
+        // ACT
+        var result = await _despatchCloudHttpClient.SetOrderStatusAsync(12331444, 1);
+
+        // ASSERT
+        Assert.False(result.IsSuccess);            
+        Assert.AreEqual("Response from DespatchCloud: 500 - Internal Server Error", result.Error);
+    }
+}


### PR DESCRIPTION

- Integration test of discovered scenario in CreateOrderAsync() when manualchannelid not valid  eg 1234 it returns 422 error
- Code returned false but with no error message created unexpected behaviour
- Refacced non 200 response handling of CreateErrorListResponse() into shared code for use with other Error creators: <ApiResponse<T>> CreateErrorApiResponse(), ask<ApiResponse> CreateErrorApiResponse()
- Unit tests on CreateOrderAsync(), SetOrderStatusAsync() and SearchOrdersAsync() which call all these error creator methods
- Handle ReasonPhrase missing from error response
