### PR TITLE
Auth token caching

### DIFF
--- a/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
+++ b/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
@@ -20,11 +20,7 @@ namespace GardeningExpress.DespatchCloudClient.Auth
 
         private static SemaphoreSlim semaphore = new SemaphoreSlim(1,1);
 
-        MemoryCacheEntryOptions cacheEntryOptions = new()
-        {
-            AbsoluteExpirationRelativeToNow =
-            TimeSpan.FromMilliseconds(60 * 1000 * 10)// 10 minute expiry
-        };
+        MemoryCacheEntryOptions cacheEntryOptions;
 
         private readonly string keyForCacheEntry = "token";
 
@@ -40,6 +36,12 @@ namespace GardeningExpress.DespatchCloudClient.Auth
             _logger = logger;
             _memoryCache = memoryCache;
             _httpClient.BaseAddress = new Uri(_despatchCloudConfig.CurrentValue.ApiBaseUrl);
+            cacheEntryOptions = new()
+            {
+                // Defaults to 10 minute expiry if no config setting
+                AbsoluteExpirationRelativeToNow =
+                TimeSpan.FromMilliseconds(60 * 1000 * _despatchCloudConfig.CurrentValue.TokenCacheExpiryMinutes) 
+            };
         }
 
         public async Task<string> GetTokenAsync()
@@ -55,7 +57,6 @@ namespace GardeningExpress.DespatchCloudClient.Auth
                     _logger.LogDebug("GetTokenAsync() returning cached token");
                     return item.ToString();
                 }
-
 
                 var loginRequest = new
                 {

--- a/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
+++ b/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
@@ -39,7 +39,6 @@ namespace GardeningExpress.DespatchCloudClient.Auth
             _despatchCloudConfig = despatchCloudConfig;
             _logger = logger;
             _memoryCache = memoryCache;
-            //_memoryCache.Set<string>(keyForCacheEntry, null);
             _httpClient.BaseAddress = new Uri(_despatchCloudConfig.CurrentValue.ApiBaseUrl);
         }
 

--- a/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
+++ b/src/Auth/GetDespatchCloudAuthenticationTokenByLoggingIn.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -14,22 +15,39 @@ namespace GardeningExpress.DespatchCloudClient.Auth
         private readonly HttpClient _httpClient;
         private readonly IOptionsMonitor<DespatchCloudConfig> _despatchCloudConfig;
         private readonly ILogger<GetDespatchCloudAuthenticationTokenByLoggingIn> _logger;
+        private readonly IMemoryCache _memoryCache;
+
+        MemoryCacheEntryOptions cacheEntryOptions = new()
+        {
+            AbsoluteExpirationRelativeToNow =
+            TimeSpan.FromMilliseconds(60 * 1000 * 10)// 10 minute expiry
+        };
+
+        private readonly string keyForCacheEntry = "token";
 
         public GetDespatchCloudAuthenticationTokenByLoggingIn(
             HttpClient httpClient,
             IOptionsMonitor<DespatchCloudConfig> despatchCloudConfig,
-            ILogger<GetDespatchCloudAuthenticationTokenByLoggingIn> logger
+            ILogger<GetDespatchCloudAuthenticationTokenByLoggingIn> logger,
+            IMemoryCache memoryCache
         )
         {
             _httpClient = httpClient;
             _despatchCloudConfig = despatchCloudConfig;
             _logger = logger;
-
+            _memoryCache = memoryCache;
+            _memoryCache.Set<Lazy<string>>(keyForCacheEntry, null);
             _httpClient.BaseAddress = new Uri(_despatchCloudConfig.CurrentValue.ApiBaseUrl);
         }
 
         public async Task<string> GetTokenAsync()
         {
+            var item = _memoryCache.Get(keyForCacheEntry);
+            if (item != null) {
+                _logger.LogDebug("GetTokenAsync() returning cached token");
+                return item.ToString();
+            }
+
             HttpResponseMessage responseMessage;
 
             try
@@ -54,7 +72,8 @@ namespace GardeningExpress.DespatchCloudClient.Auth
                 if (responseMessage.IsSuccessStatusCode)
                 {
                     var loginResponse = JsonConvert.DeserializeObject<LoginResponse>(await responseMessage.Content.ReadAsStringAsync());
-
+                    // cache it
+                    _memoryCache.Set(keyForCacheEntry, loginResponse.Token, cacheEntryOptions);
                     return loginResponse.Token;
                 }
             }

--- a/src/DespatchCloudConfig.cs
+++ b/src/DespatchCloudConfig.cs
@@ -23,6 +23,8 @@ namespace GardeningExpress.DespatchCloudClient
         public string LoginPassword { get; set; }
 
         public DespatchCloudEnvironment Environment { get; set; }
+
+        public int TokenCacheExpiryMinutes { get; set; } = 10;
     }
 
     public enum DespatchCloudEnvironment

--- a/src/GardeningExpress.DespatchCloudClient.csproj
+++ b/src/GardeningExpress.DespatchCloudClient.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace GardeningExpress.DespatchCloudClient
                     configurationSection.Bind(settings);
                 });
 
-            services.AddSingleton<AddAuthTokenHandler>();
+            services.AddTransient<AddAuthTokenHandler>();
 
             services.AddHttpClient<IGetDespatchCloudAuthenticationToken, GetDespatchCloudAuthenticationTokenByLoggingIn>((serviceProvider, client) =>
             {

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ namespace GardeningExpress.DespatchCloudClient
     {
         public static void AddDespatchCloudClient(this IServiceCollection services)
         {
+            services.AddMemoryCache();
             services.AddOptions<DespatchCloudConfig>()
                 .Configure<IConfiguration>((settings, configuration) =>
                 {
@@ -25,7 +26,7 @@ namespace GardeningExpress.DespatchCloudClient
                     configurationSection.Bind(settings);
                 });
 
-            services.AddTransient<AddAuthTokenHandler>();
+            services.AddSingleton<AddAuthTokenHandler>();
 
             services.AddHttpClient<IGetDespatchCloudAuthenticationToken, GetDespatchCloudAuthenticationTokenByLoggingIn>((serviceProvider, client) =>
             {
@@ -39,6 +40,7 @@ namespace GardeningExpress.DespatchCloudClient
                     client.BaseAddress = new Uri(options.CurrentValue.ApiBaseUrl);
                 })
                 .AddHttpMessageHandler<AddAuthTokenHandler>();
+
         }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/GetOrderByChannelOrderIdAsyncTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/GetOrderByChannelOrderIdAsyncTests.cs
@@ -32,9 +32,6 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Integration
 
             result.Error.ShouldBeNull();
             result.Data.ChannelOrderId.ShouldBe(ChannelOrderId);
-
-            var result2 = await DespatchCloudHttpClient
-              .GetOrderByChannelOrderIdAsync(ChannelOrderId);
         }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/GetOrderByChannelOrderIdAsyncTests.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Integration/GetOrderByChannelOrderIdAsyncTests.cs
@@ -32,6 +32,9 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Integration
 
             result.Error.ShouldBeNull();
             result.Data.ChannelOrderId.ShouldBe(ChannelOrderId);
+
+            var result2 = await DespatchCloudHttpClient
+              .GetOrderByChannelOrderIdAsync(ChannelOrderId);
         }
     }
 }

--- a/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Auth/GetDespatchCloudAuthenticationTokenByLoggingInShould.cs
+++ b/tests/GardeningExpress.DespatchCloudClient.Tests.Unit/Auth/GetDespatchCloudAuthenticationTokenByLoggingInShould.cs
@@ -48,6 +48,11 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Auth
             var mockLogger = new Mock<ILogger<GetDespatchCloudAuthenticationTokenByLoggingIn>>();
             
             _mockMemoryCache = new Mock<IMemoryCache>();
+            // Set defaults (eg not cached)
+            var cacheResp = null as Object;
+            _mockMemoryCache.Setup(r => r.TryGetValue(It.IsAny<Object>(), out cacheResp)).Returns(true);
+            var mockCacheEntry = new Mock<ICacheEntry>();
+            _mockMemoryCache.Setup(r => r.CreateEntry(It.IsAny<Object>())).Returns(mockCacheEntry.Object);
             _getDespatchCloudAuthenticationTokenByLoggingIn = new GetDespatchCloudAuthenticationTokenByLoggingIn(
                 httpClient, mockOptions.Object, mockLogger.Object, _mockMemoryCache.Object
             );
@@ -92,7 +97,7 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Auth
         }
 
         [Test]
-        public async Task Return_token_if_success()
+        public async Task CacheTokenInMemory_And_Return_token_if_success()
         {
             var tokenResponse = new
             {
@@ -104,7 +109,7 @@ namespace GardeningExpress.DespatchCloudClient.Tests.Unit.Auth
 
             // Act
             var token = await _getDespatchCloudAuthenticationTokenByLoggingIn.GetTokenAsync();
-
+            _mockMemoryCache.Verify(r => r.CreateEntry("token"),Times.Once);
             token.ShouldBe("this.a.token");
         }
 


### PR DESCRIPTION
To prevent multiple calls to auth/login endpoint on multiple calls / multithreaded calls to dclient endpoints over the life of the client

- added Microsoft.Extensions.Caching.Memory IMemoryCache using IMemoryCache to store token (decided against redis for sec reasons or statics as client may be used in a long running process, memorycache has an expiry set to deal with token expiring)
- Use semaphoreslim to prevent multithreading race conditions accessing / updating memory cache (eg when using durable function  orchestrator fan-out pattern to make dclient calls)
- Tested in automations envioronment, only one call to auth/login and no detected long running threads of PushGoGroopieOrderToDC task
- New DespatchCloudClientConfig setting TokenCacheExpiryMinutes defaulted to 10 minutes (non breaking change)

